### PR TITLE
Decrease distance bars to match stock Honda behavior

### DIFF
--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -350,7 +350,7 @@ class CarState(CarStateBase):
     # When user presses distance button on steering wheel. Must be above LKAS button code, cannot be below!
     if self.cruise_setting == 3:
       if cp.vl["SCM_BUTTONS"]["CRUISE_SETTING"] == 0:
-        self.trMode = (self.trMode + 1 ) % 4
+        self.trMode = (self.trMode - 1 ) % 4
 
     self.prev_cruise_setting = self.cruise_setting
     self.cruise_setting = cp.vl["SCM_BUTTONS"]['CRUISE_SETTING']


### PR DESCRIPTION
Self explanatory.

Other commits I have on my default branch that you may like include:
- Enable LKAS if Set or Resume is pressed (may be useful to have this option on a toggle)
- Allow LKAS below engage speed (otherwise it won't re-engage when you release the brake under 25mph)